### PR TITLE
FactoryDefinition::addSetup() is deprecated

### DIFF
--- a/src/Bridges/Nette/Extension.php
+++ b/src/Bridges/Nette/Extension.php
@@ -43,7 +43,7 @@ class Extension extends CompilerExtension
 
         // load macro to latte
         $latteFactory = $builder->getDefinition('latte.latteFactory');
-        $latteFactory->addSetup(MacroThumb::class . '::install(?->getCompiler())', ['@self']);
+        $latteFactory->getResultDefinition()->addSetup(MacroThumb::class . '::install(?->getCompiler())', ['@self']);
     }
 
 


### PR DESCRIPTION
In Nette 3 is deprecation of FactoryDefinition::addSetup(). More on https://forum.nette.org/cs/31432-vysla-prvni-betaverze-nette-di-3-0-pojdte-ji-otestovat#p200490.

![obrazek](https://user-images.githubusercontent.com/750954/85301753-83628a00-b4a8-11ea-9140-4934f3203d13.png)

This pull request fixes that, but it is probably not compatible with Nette 2.4. Maybe this can be in new version with Nette 3 requirements?
